### PR TITLE
FIX: Unable to set allowed groups to everyone group

### DIFF
--- a/javascripts/discourse/api-initializers/discourse-copy-post.js
+++ b/javascripts/discourse/api-initializers/discourse-copy-post.js
@@ -1,4 +1,5 @@
 import { apiInitializer } from "discourse/lib/api";
+import { AUTO_GROUPS } from "discourse/lib/constants";
 import CopyPostButton from "../components/copy-post-button";
 
 export default apiInitializer("2.0.0", (api) => {
@@ -6,8 +7,10 @@ export default apiInitializer("2.0.0", (api) => {
   const currentUserGroupIds = currentUser.groups.map((group) => group.id);
   const allowedGroups = settings.copy_button_allowed_groups;
   const allowedGroupIds = allowedGroups.split("|").map(Number);
-  const userNotAllowed = !allowedGroupIds.some((groupId) =>
-    currentUserGroupIds.includes(groupId)
+  const userNotAllowed = !allowedGroupIds.some(
+    (groupId) =>
+      currentUserGroupIds.includes(groupId) ||
+      groupId === AUTO_GROUPS.everyone.id
   );
 
   if (userNotAllowed) {

--- a/spec/system/copy_post_spec.rb
+++ b/spec/system/copy_post_spec.rb
@@ -48,7 +48,7 @@ RSpec.describe "Copy post spec", system: true do
     before do
       theme_component.update_setting(
         :copy_button_allowed_groups,
-        [Group::AUTO_GROUPS[:trust_level_4]],
+        Group::AUTO_GROUPS[:trust_level_4].to_s,
       )
       theme_component.save!
     end
@@ -56,6 +56,36 @@ RSpec.describe "Copy post spec", system: true do
     it "should not show the copy post button" do
       topic_page.visit_topic(topic)
       expect(copy_post_button).to have_no_copy_post_button(post.post_number)
+    end
+  end
+
+  context "when user is a member of the allowed groups" do
+    before do
+      theme_component.update_setting(
+        :copy_button_allowed_groups,
+        Group::AUTO_GROUPS[:trust_level_1].to_s,
+      )
+      theme_component.save!
+    end
+
+    it "should show the copy post button" do
+      topic_page.visit_topic(topic)
+      expect(copy_post_button).to have_copy_post_button(post.post_number)
+    end
+  end
+
+  context "when allowed groups is set to everyone group" do
+    before do
+      theme_component.update_setting(
+        :copy_button_allowed_groups,
+        Group::AUTO_GROUPS[:everyone].to_s,
+      )
+      theme_component.save!
+    end
+
+    it "should show the copy post button" do
+      topic_page.visit_topic(topic)
+      expect(copy_post_button).to have_copy_post_button(post.post_number)
     end
   end
 end


### PR DESCRIPTION
### :mag: Overview
This update fixes an issue where the copy post button does not show up when it is set to the "everyone" group. This is because the "everyone" group is not a `visible_group`, and only visible groups are attached to the current user's serializer. Hence, we must explicitly check for the everyone group when comparing against the current user's groups.

### 🔗 Related links
https://meta.discourse.org/t/copy-post-component/218883/22?u=keegan