### PR TITLE
DEV: Use resolve_group_membership core theme functionality

### DIFF
--- a/javascripts/discourse/api-initializers/discourse-copy-post.js
+++ b/javascripts/discourse/api-initializers/discourse-copy-post.js
@@ -2,22 +2,48 @@ import { apiInitializer } from "discourse/lib/api";
 import { AUTO_GROUPS } from "discourse/lib/constants";
 import CopyPostButton from "../components/copy-post-button";
 
-export default apiInitializer((api) => {
-  const currentUser = api.getCurrentUser();
-  const currentUserGroupIds = currentUser?.groups.map((group) => group.id);
-  const allowedGroups = settings.copy_button_allowed_groups;
-  const allowedGroupIds = allowedGroups.split("|").map(Number);
-  const userNotAllowed = !allowedGroupIds.some(
-    (groupId) =>
-      currentUserGroupIds?.includes(groupId) ||
-      groupId === AUTO_GROUPS.everyone.id
-  );
-
-  if (userNotAllowed) {
-    return;
+function shouldRenderCopyButton(currentUser) {
+  // Using resolve_group_membership on theme settings
+  if (Object.hasOwn(settings, "user_in_copy_button_allowed_groups")) {
+    if (settings.user_in_copy_button_allowed_groups) {
+      return true;
+    }
   }
 
-  api.registerValueTransformer("post-menu-buttons", ({ value: dag }) => {
-    dag.add("copy-post", CopyPostButton);
-  });
+  // Backwards compat, remove this once the user_in_X functionality
+  // for theme settings is in core.
+  const allowedGroupIds = settings.copy_button_allowed_groups
+    .split("|")
+    .filter(Boolean)
+    .map(Number);
+
+  if (!currentUser) {
+    if (!allowedGroupIds.includes(AUTO_GROUPS.anonymous_users.id)) {
+      return false;
+    }
+  }
+
+  const currentUserGroupIds = currentUser.groups.map((group) => group.id);
+  if (
+    !allowedGroupIds.some(
+      (groupId) =>
+        currentUserGroupIds.includes(groupId) ||
+        groupId === AUTO_GROUPS.everyone.id ||
+        groupId === AUTO_GROUPS.logged_in_users.id
+    )
+  ) {
+    return false;
+  }
+
+  return true;
+}
+
+export default apiInitializer((api) => {
+  const currentUser = api.getCurrentUser();
+
+  if (shouldRenderCopyButton(currentUser)) {
+    api.registerValueTransformer("post-menu-buttons", ({ value: dag }) => {
+      dag.add("copy-post", CopyPostButton);
+    });
+  }
 });

--- a/settings.yml
+++ b/settings.yml
@@ -10,3 +10,4 @@ copy_button_allowed_groups:
   list_type: group
   default: "11" # trust_level_1
   description: "Select the groups that are allowed to use the copy button."
+  resolve_group_membership: true

--- a/spec/system/copy_post_anonymous_spec.rb
+++ b/spec/system/copy_post_anonymous_spec.rb
@@ -12,11 +12,11 @@ RSpec.describe "Copy post spec - anonymous", system: true do
   let(:copy_post_button) { PageObjects::Components::CopyPostButton.new }
   let!(:theme_component) { upload_theme_component }
 
-  context "when allowed groups is set to everyone group and user is logged out" do
+  context "when allowed groups is set to anonymous_users group and user is logged out" do
     before do
       theme_component.update_setting(
         :copy_button_allowed_groups,
-        Group::AUTO_GROUPS[:everyone].to_s,
+        Group::AUTO_GROUPS[:anonymous_users].to_s,
       )
       theme_component.save!
     end

--- a/spec/system/copy_post_spec.rb
+++ b/spec/system/copy_post_spec.rb
@@ -75,11 +75,11 @@ RSpec.describe "Copy post spec", system: true do
     end
   end
 
-  context "when allowed groups is set to everyone group" do
+  context "when allowed groups is set to logged_in_users group" do
     before do
       theme_component.update_setting(
         :copy_button_allowed_groups,
-        Group::AUTO_GROUPS[:everyone].to_s,
+        Group::AUTO_GROUPS[:logged_in_users].to_s,
       )
       theme_component.save!
     end


### PR DESCRIPTION
See https://github.com/discourse/discourse/pull/41360,
group list theme settings can now use resolve_group_membership: true
and a special user_in_X property will be injected on the theme
settings object, so we can check this on the frontend instead
of looking at currentUser.groups, which may not include all
groups the user is a member of.
